### PR TITLE
Fix set_environ removal when value None

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -732,24 +732,26 @@ def is_valid_cidr(string_network):
 
 @contextlib.contextmanager
 def set_environ(env_name, value):
-    """Set the environment variable 'env_name' to 'value'
+    """Temporarily set or unset an environment variable.
 
-    Save previous value, yield, and then restore the previous value stored in
-    the environment variable 'env_name'.
+    The previous value is restored after the context manager exits. If
+    ``value`` is ``None`` the variable will be removed within the context.
+    """
 
-    If 'value' is None, do nothing"""
-    value_changed = value is not None
-    if value_changed:
-        old_value = os.environ.get(env_name)
+    old_exists = env_name in os.environ
+    old_value = os.environ.get(env_name)
+
+    if value is None:
+        os.environ.pop(env_name, None)
+    else:
         os.environ[env_name] = value
     try:
         yield
     finally:
-        if value_changed:
-            if old_value is None:
-                del os.environ[env_name]
-            else:
-                os.environ[env_name] = old_value
+        if old_exists:
+            os.environ[env_name] = old_value
+        else:
+            os.environ.pop(env_name, None)
 
 
 def should_bypass_proxies(url, no_proxy):

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -732,20 +732,20 @@ def is_valid_cidr(string_network):
 
 @contextlib.contextmanager
 def set_environ(env_name, value):
-    """Temporarily set or unset an environment variable.
+    """Temporarily set or remove an environment variable.
 
-    The previous value is restored after the context manager exits. If
-    ``value`` is ``None`` the variable will be removed within the context.
+    The variable is deleted while inside the context when ``value`` is ``None``.
+    Whatever existed beforehand is restored once the context exits.
     """
 
     old_exists = env_name in os.environ
     old_value = os.environ.get(env_name)
 
-    if value is None:
-        os.environ.pop(env_name, None)
-    else:
-        os.environ[env_name] = value
     try:
+        if value is None:
+            os.environ.pop(env_name, None)
+        else:
+            os.environ[env_name] = value
         yield
     finally:
         if old_exists:


### PR DESCRIPTION
## Summary
- make `set_environ` remove existing variables when value is `None`
- update docstring to reflect new behavior

## Testing
- `pytest tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688af0abde4c83218eddfe3c58e81e5e